### PR TITLE
Allows configuring custom field tooltip for Zapp UI

### DIFF
--- a/lib/custom_fields_questions_helper.rb
+++ b/lib/custom_fields_questions_helper.rb
@@ -30,13 +30,19 @@ module CustomFieldsQuestionsHelper
       ManifestHelpers::TOOLTIP_TYPES.map{ |t| t[:value] }
     )
 
-    field_hash[:tooltip_type] = ManifestHelpers::TOOLTIP_TYPES[tooltip_type_selection][:type]
+    tooltip_type = ManifestHelpers::TOOLTIP_TYPES[tooltip_type_selection][:type]
 
     field_hash[:tooltip_text] =
-      if field_hash[:tooltip_type] == :plain
+      case tooltip_type
+      when :plain
         Question.required_with_min_length("Enter the tooltip value to be displayed in the Zapp UI", "Tooltip text", 10)
-      else
-        Question.required_with_url_validation("Enter the URL to be displayed", "Tooltip URL")
+      when :url
+        url = Question.required_with_url_validation("Enter the URL to be displayed", "Tooltip URL")
+        "You can read more about it <a href=#{url} target=_blank>here</a>"
+      when :mixed
+        text = Question.ask_base("Enter the tooltip value to be displayed in the Zapp UI")
+        url = Question.required_with_url_validation("Enter the URL to be displayed", "Tooltip URL")
+        "#{text}. You can read more about it <a href=#{url} target=_blank>here</a>"
       end
 
     if field_hash[:type] == :dropdown

--- a/lib/custom_fields_questions_helper.rb
+++ b/lib/custom_fields_questions_helper.rb
@@ -35,14 +35,14 @@ module CustomFieldsQuestionsHelper
     field_hash[:tooltip_text] =
       case tooltip_type
       when :plain
-        Question.required_with_min_length("Enter the tooltip value to be displayed in the Zapp UI", "Tooltip text", 10)
+        Question.required_with_min_length("Enter the tooltip text to be displayed in the Zapp UI", "Tooltip text", 10)
       when :url
         url = Question.required_with_url_validation("Enter the URL to be displayed", "Tooltip URL")
-        "You can read more about it <a href=#{url} target=_blank>here</a>"
+        "To learn about this field, click <a href=#{url} target=_blank>here</a>."
       when :mixed
-        text = Question.ask_base("Enter the tooltip value to be displayed in the Zapp UI")
+        text = Question.ask_base("Enter the tooltip text to be displayed in the Zapp UI")
         url = Question.required_with_url_validation("Enter the URL to be displayed", "Tooltip URL")
-        "#{text}. You can read more about it <a href=#{url} target=_blank>here</a>"
+        "#{text}. \nTo learn more about it, click <a href=#{url} target=_blank>here</a>."
       end
 
     if field_hash[:type] == :dropdown

--- a/lib/custom_fields_questions_helper.rb
+++ b/lib/custom_fields_questions_helper.rb
@@ -25,8 +25,19 @@ module CustomFieldsQuestionsHelper
     field_hash[:type] = ManifestHelpers::INPUT_FIELD_TYPES[input_type_index]
 
     field_hash[:key] = Question.ask_non_whitespaces("What is the key for this field?", "Custom key")
-    field_hash[:tooltip_text] = Question
-      .required_with_min_length("Enter a text the UI tooltip in Zapp", "Tooltip text", 10)
+    tooltip_type_selection = Question.multiple_option_question(
+      "[?] What type of tooltip would you like to display for this field",
+      ManifestHelpers::TOOLTIP_TYPES.map{ |t| t[:value] }
+    )
+
+    field_hash[:tooltip_type] = ManifestHelpers::TOOLTIP_TYPES[tooltip_type_selection][:type]
+
+    field_hash[:tooltip_text] =
+      if field_hash[:tooltip_type] == :plain
+        Question.required_with_min_length("Enter the tooltip value to be displayed in the Zapp UI", "Tooltip text", 10)
+      else
+        Question.required_with_url_validation("Enter the URL to be displayed", "Tooltip URL")
+      end
 
     if field_hash[:type] == :dropdown
       field_hash[:multiple] = agree "[?] Multiple select?"

--- a/lib/custom_fields_questions_helper.rb
+++ b/lib/custom_fields_questions_helper.rb
@@ -25,6 +25,8 @@ module CustomFieldsQuestionsHelper
     field_hash[:type] = ManifestHelpers::INPUT_FIELD_TYPES[input_type_index]
 
     field_hash[:key] = Question.ask_non_whitespaces("What is the key for this field?", "Custom key")
+    field_hash[:tooltip_text] = Question
+      .required_with_min_length("Enter a text the UI tooltip in Zapp", "Tooltip text", 10)
 
     if field_hash[:type] == :dropdown
       field_hash[:multiple] = agree "[?] Multiple select?"

--- a/lib/manifest_helpers.rb
+++ b/lib/manifest_helpers.rb
@@ -52,7 +52,8 @@ module ManifestHelpers
 
   TOOLTIP_TYPES = [
     { type: :plain, value: "Plain text"},
-    { type: :url, value: "A link to an external resource"}
+    { type: :url, value: "A link to an external resource"},
+    { type: :mixed, value: "Text with a link to an external resource"}
   ].freeze
 
   module_function

--- a/lib/manifest_helpers.rb
+++ b/lib/manifest_helpers.rb
@@ -50,6 +50,11 @@ module ManifestHelpers
 
   INPUT_FIELD_TYPES = %i(text checkbox textarea dropdown tags colorpicker)
 
+  TOOLTIP_TYPES = [
+    { type: :plain, value: "Plain text"},
+    { type: :url, value: "A link to an external resource"}
+  ].freeze
+
   module_function
 
   def create_file(manifest_hash)

--- a/lib/question.rb
+++ b/lib/question.rb
@@ -16,6 +16,15 @@ module Question
   end
 
   def ask_base(question)
-    ask("[?] #{question}")
+    ask("[?] #{question}") do |q|
+      yield(q) if block_given?
+    end
+  end
+
+  def required_with_min_length(question, field_name, min_length = 10)
+    ask_base(question) do |q|
+      q.validate = /.{#{min_length},}/
+      q.responses[:not_valid] = "#{field_name} must have a minimum length of #{min_length}."
+    end
   end
 end

--- a/lib/question.rb
+++ b/lib/question.rb
@@ -21,10 +21,21 @@ module Question
     end
   end
 
+  def multiple_option_question(question, answer_options)
+    Ask.list(question, answer_options)
+  end
+
   def required_with_min_length(question, field_name, min_length = 10)
     ask_base(question) do |q|
       q.validate = /.{#{min_length},}/
       q.responses[:not_valid] = "#{field_name} must have a minimum length of #{min_length}."
+    end
+  end
+
+  def required_with_url_validation(question, field_name)
+    ask_base(question) do |q|
+      q.validate = /^(http|https):\/\/|[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/
+      q.responses[:not_valid] = "#{field_name} must be a valid URL. (i.e http://www.a-domain.com/some-resource)"
     end
   end
 end


### PR DESCRIPTION
@ranmeirman 
Here we ask from the plugin configuration creator to add a text that will be used in Zapp UI in order to make it more clear when navigating through custom added fields

Update

The manifest will now have:

```JSON
...
"custom_configuration_fields": [
    {
      "type": "text",
      "key": "welcome",
      "tooltip_text": "This should appear when launching the login screen",    // Added
      "default": "Hello!, world"
    },
   {
      "type": "dropdown",
      "key": "data_source",
      "tooltip_text": "This will point to the source to be used for the data origin", //Added
      "multiple": false,
      "options": [
        "appli2",
        "3rdparty"
      ],
      "default": "appli2"
    }
  ]
...
```