### PR TITLE
add react_bundle_url field to field validation

### DIFF
--- a/lib/manifest_helpers.rb
+++ b/lib/manifest_helpers.rb
@@ -25,6 +25,7 @@ module ManifestHelpers
     "npm_dependencies",
     "scheme",
     "data_types",
+    "react_bundle_url",
   ]
 
   Types = [


### PR DESCRIPTION
This PR adds validation for the `react_bundle_url` field introduced in #65 