### PR TITLE
Dependency/Package is now optional for plugins.

### DIFF
--- a/lib/default_questions_helper.rb
+++ b/lib/default_questions_helper.rb
@@ -33,8 +33,11 @@ module DefaultQuestionsHelper
       ask_for_dependency_repository(manifest_hash)
     end
 
-    manifest_hash[:dependency_name] = Question.ask_non_whitespaces("Package name:", "Package name")
-    manifest_hash[:dependency_version] = Question.ask_non_whitespaces("Package version:", "Package version")
+    package_name = Question.ask_base("Package name:")
+    if !package_name.empty?
+      manifest_hash[:dependency_name] = package_name
+      manifest_hash[:dependency_version] = Question.ask_non_whitespaces("Package version:", "Package version")
+    end
     manifest_hash[:whitelisted_account_ids] = []
 
     whitelisted_account_ids = Question.ask_base("Whitelisted account ids: (comma seperated, leave blank if no restrictions apply)")

--- a/lib/default_questions_helper.rb
+++ b/lib/default_questions_helper.rb
@@ -34,10 +34,12 @@ module DefaultQuestionsHelper
     end
 
     package_name = Question.ask_base("Package name:")
-    if !package_name.empty?
+
+    unless package_name.empty?
       manifest_hash[:dependency_name] = package_name
       manifest_hash[:dependency_version] = Question.ask_non_whitespaces("Package version:", "Package version")
     end
+
     manifest_hash[:whitelisted_account_ids] = []
 
     whitelisted_account_ids = Question.ask_base("Whitelisted account ids: (comma seperated, leave blank if no restrictions apply)")


### PR DESCRIPTION
Zapptool has also been updated to allow for these values to be `nil`: https://github.com/applicaster/ZappTool/pull/136