### PR TITLE
improve query to get the current plugin, and fix request params sent …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.3.0)
+    ast (2.4.0)
     blockenspiel (0.5.0)
     coderay (1.1.2)
     colorize (0.8.1)
@@ -15,17 +15,19 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    parser (2.4.0.0)
-      ast (~> 2.2)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     powerpack (0.1.1)
     pry (0.11.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (2.2.2)
       rake
-    rake (12.1.0)
-    rubocop (0.41.2)
-      parser (>= 2.3.1.1, < 3.0)
+    rake (12.3.0)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -50,7 +52,7 @@ DEPENDENCIES
   inquirer
   mime-types
   pry
-  rubocop (~> 0.41.1)
+  rubocop (~> 0.49.0)
   terminal-table
   versionomy
 

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -6,8 +6,6 @@ class Plugin < PluginBase
   def initialize(options)
     super(options)
     @existing_plugin = zapp_plugin
-    puts zapp_plugin
-    exit
     @id = @existing_plugin["id"] unless @existing_plugin.nil?
   end
 

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -6,6 +6,8 @@ class Plugin < PluginBase
   def initialize(options)
     super(options)
     @existing_plugin = zapp_plugin
+    puts zapp_plugin
+    exit
     @id = @existing_plugin["id"] unless @existing_plugin.nil?
   end
 
@@ -29,12 +31,16 @@ class Plugin < PluginBase
         p["name"] == @name || identifier_matches?(p)
       end
 
-    return nil if plugin_candidates.count == 0
-    return plugin_candidates.first if plugin_candidates.count == 1
-
-    plugin_identifiers = plugin_candidates.map { |p| p["external_identifier"] }
-    identifier_index = multiple_option_question("Please select your plugin :", plugin_identifiers)
-    plugin_candidates[identifier_index]
+    case plugin_candidates.count
+    when 0
+      nil
+    when 1
+      plugin_candidates.first
+    else
+      plugin_identifiers = plugin_candidates.map { |p| p["external_identifier"] }
+      identifier_index = multiple_option_question("Please select your plugin :", plugin_identifiers)
+      plugin_candidates[identifier_index]
+    end
   end
 
   def identifier_matches?(plugin)

--- a/lib/plugin_base.rb
+++ b/lib/plugin_base.rb
@@ -6,7 +6,7 @@ class PluginBase
   def initialize(options)
     @manifest = get_manifest_data(options)
     @name = @manifest["name"]
-    @identifier = @manifest["identifier"]
+    @identifier = format_identifier(@manifest["identifier"])
     @base_url = options.override_url || NetworkHelpers::ZAPP_URL
     @access_token = options.access_token
   end
@@ -26,5 +26,9 @@ class PluginBase
   def get_manifest_data(options)
     manifest_file = File.open(options.manifest)
     JSON.parse(File.read(manifest_file))
+  end
+
+  def format_identifier(identifier)
+    identifier.gsub(/((_|-)(ios|android))/i, "")
   end
 end

--- a/lib/plugin_version.rb
+++ b/lib/plugin_version.rb
@@ -72,9 +72,14 @@ class PluginVersion < PluginBase
       params["plugin_version[manifest]"] = @manifest.to_json
       params["plugin_version[author_email]"] = @manifest["author_email"]
       params["plugin_version[version]"] = @manifest["manifest_version"]
-      params["plugin_version[platform]"] = @manifest["platform"] || nil
+      params["plugin_version[platform]"] = platform
       params["plugin_version[scheme]"] = @manifest["scheme"]
       params["plugin_version[whitelisted_account_ids][]"] = @manifest["whitelisted_account_ids"]
     end
+  end
+
+  def platform
+    return if @manifest["platform"] == ""
+    @manifest["platform"]
   end
 end

--- a/lib/plugin_version.rb
+++ b/lib/plugin_version.rb
@@ -65,14 +65,14 @@ class PluginVersion < PluginBase
     {}.tap do |params|
       params["id"] = @id unless @id.nil?
       params["access_token"] = @access_token
-      params["plugin_version[name]"] = @manifest["name"]
-      params["plugin_version[identifier]"] = @manifest["identifier"]
+      params["plugin_version[name]"] = @name
+      params["plugin_version[identifier]"] = @identifier
       params["plugin_version[category]"] = @manifest["type"]
       params["plugin_version[plugin_id]"] = @plugin.id
       params["plugin_version[manifest]"] = @manifest.to_json
       params["plugin_version[author_email]"] = @manifest["author_email"]
       params["plugin_version[version]"] = @manifest["manifest_version"]
-      params["plugin_version[platform]"] = @manifest["platform"]
+      params["plugin_version[platform]"] = @manifest["platform"] || nil
       params["plugin_version[scheme]"] = @manifest["scheme"]
       params["plugin_version[whitelisted_account_ids][]"] = @manifest["whitelisted_account_ids"]
     end

--- a/lib/plugin_version.rb
+++ b/lib/plugin_version.rb
@@ -79,7 +79,7 @@ class PluginVersion < PluginBase
   end
 
   def platform
-    return if @manifest["platform"] == ""
+    return if @manifest["platform"].empty?
     @manifest["platform"]
   end
 end


### PR DESCRIPTION
…to zapp

This PR solves edge cases where the plugin identifier from the manifest isn't exactly like the one in zapp (for instance, it has the platform has suffix)

it also fixes the request params sent for plugin & plugin_version