### PR TITLE
fix error complaining about calling `[]` on nil object

### DIFF
--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -9,7 +9,7 @@ class Plugin < PluginBase
 
   def find_zapp_plugin
     @existing_plugin = zapp_plugin unless @create_new_plugin
-    @id = @existing_plugin["id"] unless @existing_plugin
+    @id = @existing_plugin["id"] unless @existing_plugin.nil?
   end
 
   def create


### PR DESCRIPTION
this PR fixes this error when using the `--new` option
![image](https://user-images.githubusercontent.com/15126070/35595830-4abab808-0618-11e8-8e10-d0eef13f6708.png)
