### PR TITLE
fix parsing error when manifest has no platform field

### DIFF
--- a/lib/plugin_version.rb
+++ b/lib/plugin_version.rb
@@ -84,7 +84,7 @@ class PluginVersion < PluginBase
   end
 
   def platform
-    return if @manifest["platform"].empty?
+    return if @manifest["platform"].nil? || @manifest["platform"].empty?
     @manifest["platform"]
   end
 end


### PR DESCRIPTION
This PR fixes a bug where a manifest with no `platform` field is causing an error