### PR TITLE
feat(whitelisted accounts): force whitelisted accounts, add accounts loader and helper

### DIFF
--- a/lib/manifest_helpers.rb
+++ b/lib/manifest_helpers.rb
@@ -87,11 +87,6 @@ module ManifestHelpers
     end
   end
 
-  def ensure_whitelisted_accounts(manifest_hash)
-    return if manifest_hash.keys.include?("whitelisted_account_ids")
-    manifest_hash["whitelisted_account_ids"] = []
-  end
-
   def whitelisted_keys
     MANDATORY_KEYS + OPTIONAL_KEYS
   end

--- a/lib/network_helpers.rb
+++ b/lib/network_helpers.rb
@@ -72,6 +72,11 @@ module NetworkHelpers
       .response
   end
 
+  def get_accounts_list(options)
+    uri = URI.parse("#{ACCOUNTS_URL}/accounts.json")
+    Request.new(uri, { "access_token" => options.access_token }).do_request(:get).response
+  end
+
   def respond_to_missing?(method_name, include_private = false)
     %w(get_request put_request post_request).include?(method_name)
   end


### PR DESCRIPTION
Forcing whitelisted accounts - a user will not be able to publish public plugin.

This PR includes:
1. Zappifest validates the presence of minimum one id in whitelisted account ids
2. Loading accounts from `Applicaster Accounts` to allow users to use names instead of finding ids
3. Due to the fact accounts list is a long list, selector is not valuable, instead this PR introduces TAB key autocompletion.

* not updating version as there are more PRs to come :)
* Autocomplete reference in ruby docs: https://ruby-doc.org/stdlib-2.1.1/libdoc/readline/rdoc/Readline.html
<img width="1358" alt="screen shot 2018-06-29 at 10 50 01 am" src="https://user-images.githubusercontent.com/3055682/42099109-9fcb1684-7b8a-11e8-9a56-eb12b020f1ff.png">
