### PR TITLE
feat(keys): adds additional optional keys

### DIFF
--- a/lib/manifest_helpers.rb
+++ b/lib/manifest_helpers.rb
@@ -47,6 +47,8 @@ module ManifestHelpers
     "guide",
     "core_plugin",
     "configuration_panel_disabled",
+    "export",
+    "import",
   ]
 
   Types = [

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -64,12 +64,17 @@ class Plugin < PluginBase
       params["plugin[about]"] = @plugin_about
       params["plugin[core_plugin]"] = @manifest["core_plugin"] || false
       params["plugin[screen]"] = @manifest["screen"] || false
-      params["plugin[exports]"] = @manifest["export"].has_key?("allowed_list") || false
+      params["plugin[exports]"] = plugin_exports?
       params["plugin[configuration_panel_disabled]"] = @manifest["configuration_panel_disabled"] || false
       params["plugin[cover_image]"] = @manifest["cover_image"]
       params["plugin[ui_builder_support]"] = @manifest["ui_builder_support"]
       params["plugin[preview_image]"] = preview_image
     end
+  end
+
+  def plugin_exports?
+    return false unless @manifest["export"]
+    @manifest["export"].has_key?("allowed_list")
   end
 
   def plugin_requires_update?

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -64,6 +64,7 @@ class Plugin < PluginBase
       params["plugin[about]"] = @plugin_about
       params["plugin[core_plugin]"] = @manifest["core_plugin"] || false
       params["plugin[screen]"] = @manifest["screen"] || false
+      params["plugin[exports]"] = @manifest["export"].has_key?("allowed_list") || false
       params["plugin[configuration_panel_disabled]"] = @manifest["configuration_panel_disabled"] || false
       params["plugin[cover_image]"] = @manifest["cover_image"]
       params["plugin[ui_builder_support]"] = @manifest["ui_builder_support"]


### PR DESCRIPTION
This PR adds additional optional keys for the  "plugin to plugin" task.

please test it when you on the `feat/plugin-adds-exports-field` branch in zapp