### PR TITLE
fix(publish): updating a plugin allowed publishing without whitelisted accounts

### DIFF
--- a/lib/manifest_helpers.rb
+++ b/lib/manifest_helpers.rb
@@ -97,8 +97,12 @@ module ManifestHelpers
     MANDATORY_KEYS + OPTIONAL_KEYS
   end
 
-  def valid_account_ids?(manifest, options)
-    return true unless options.new
-    manifest["whitelisted_account_ids"] && manifest["whitelisted_account_ids"].any?
+  def valid_account_ids?(plugin_version)
+    return true if allow_public_plugin?(plugin_version)
+    return plugin_version.manifest["whitelisted_account_ids"] && plugin_version.manifest["whitelisted_account_ids"].any?
+  end
+
+  def allow_public_plugin?(plugin_version)
+    plugin_version.plugin.public_plugin?
   end
 end

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -3,13 +3,18 @@ require_relative 'plugin_base'
 class Plugin < PluginBase
   include Question
 
+  attr_accessor :id, :existing_plugin
+
   def initialize(options)
     super(options)
-  end
-
-  def find_zapp_plugin
     @existing_plugin = zapp_plugin unless @create_new_plugin
     @id = @existing_plugin["id"] unless @existing_plugin.nil?
+  end
+
+  def public_plugin?
+    return unless existing_plugin
+    return true unless @existing_plugin["whitelisted_account_ids"]
+    @existing_plugin["whitelisted_account_ids"].blank?
   end
 
   def create

--- a/lib/plugin_version.rb
+++ b/lib/plugin_version.rb
@@ -1,7 +1,7 @@
 require_relative 'plugin_base'
 
 class PluginVersion < PluginBase
-  attr_accessor :manifest
+  attr_accessor :manifest, :plugin
 
   def initialize(options)
     super(options)
@@ -42,7 +42,6 @@ class PluginVersion < PluginBase
   end
 
   def publish
-    @plugin.find_zapp_plugin
     @id ? update : create
   end
 
@@ -65,7 +64,7 @@ class PluginVersion < PluginBase
 
   def check_manifest_version_validity
     Versionomy.parse(@manifest["manifest_version"])
-  rescue => error
+  rescue
     color "Plugin version #{@manifest["manifest_version"]} is not valid", :red
     exit
   end

--- a/lib/zappifest.rb
+++ b/lib/zappifest.rb
@@ -114,7 +114,7 @@ command :publish do |c|
 
     plugin_version = PluginVersion.new(options)
 
-    unless ManifestHelpers.valid_account_ids?(plugin_version.manifest, options)
+    unless ManifestHelpers.valid_account_ids?(plugin_version)
       color "Manifest must contain at least one whitelisted account id", :red
       exit
     end


### PR DESCRIPTION
This PR fixes a bug that was allowing to publish a plugin without whitelisted account, causing for custom plugins to be public