### PR TITLE
feat(new option): max_items_per_type

### DIFF
--- a/lib/manifest_helpers.rb
+++ b/lib/manifest_helpers.rb
@@ -41,6 +41,7 @@ module ManifestHelpers
     "screen",
     "supported_nav_items",
     "max_nav_items",
+    "max_items_per_type",
     "zapp_configuration",
     "summary",
     "cover_image",


### PR DESCRIPTION
This PR adds a new manifest option `max_items_per_type`

the number of the same navigation item that can be added for navigation.