### PR TITLE
fix(dev): Check local dev token

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,14 @@ You can use markdown files to populate the `guide` and `description` fields of t
 $ zappifest publish --manifest <path-to-manifest-json-file> --access-token <zapp-access-token> --plugin-about <path-to-about.md>
 ```
 
-### Overriding endpoint
-You can override the remote end point using `--override-url http://localhost:{your-port}/api/v1/admin`
+### Overriding endpoints
+When working vs local or stage server(s), it is imperative to override the url for the Zapp and accounts servers:
+- Zapp server override: `--base-url http://localhost:{your-port}/api/v1/admin`
+- Accounts server override: `--accounts-url http://accounts.test/api/v1`
+Example for updating a plugin _locally_, given a zapp server up and running on `localhost:4000` and an accout server running via `pow`:
+```
+ruby lib/zappifest.rb publish --plugin-id 1234 --manifest <path-to-manifest-json-file> --access-token <local-zapp-access-token> --base-url http://localhost:4000/api/v1/admin --accounts-url http://accounts.test/api/v1
+```
 
 ### Contributing
 1. `git clone https://github.com/applicaster/zappifest.git`

--- a/lib/default_questions_helper.rb
+++ b/lib/default_questions_helper.rb
@@ -4,7 +4,7 @@ module DefaultQuestionsHelper
   def ask_base_questions(options, manifest_hash = { api: {}, dependency_repository_url: [], platform: nil })
     manifest_hash[:manifest_version] = Question.ask_for_version("Plugin manifest version (this key will set the plugin version in Zapp):", true, "0.1.0")
 
-    current_user = NetworkHelpers.current_user(options.access_token).body
+    current_user = NetworkHelpers.current_user(options).body
     manifest_hash[:author_email] = current_user["email"]
     manifest_hash[:author_name] = current_user["name"]
     color "*** Author name and email was set to '#{manifest_hash[:author_name]}' and '#{manifest_hash[:author_email]}' using Zapp token *** \n "

--- a/lib/network_helpers.rb
+++ b/lib/network_helpers.rb
@@ -60,28 +60,28 @@ module NetworkHelpers
 
   module_function
 
-  def current_user(access_token)
-    uri = URI.parse("#{ACCOUNTS_URL}/users/current.json")
-    Request.new(uri, { "access_token" => access_token }).do_request(:get)
+  def current_user(options)
+    uri = URI.parse("#{options.accounts_url}/users/current.json")
+    Request.new(uri, { "access_token" => options.access_token }).do_request(:get)
   end
 
-  def validate_token(access_token)
-    unless access_token
+  def validate_token(options)
+    unless options.access_token
       color "Access token is missing"
       exit
     end
 
-    current_user(access_token)
+    current_user(options)
   end
 
   def get_accounts_list(options)
-    uri = URI.parse("#{ACCOUNTS_URL}/accounts.json")
+    uri = URI.parse("#{options.accounts_url}/accounts.json")
     Request.new(uri, { "access_token" => options.access_token }).do_request(:get)
   end
 
   def get_zapp_sdks(platform, options)
     uri = URI.parse(
-      "#{ZAPP_URL}/sdk_versions.json?by_platform=#{platform}&status=stable&stable_channel_by_version=true",
+      "#{options.base_url}/sdk_versions.json?by_platform=#{platform}&status=stable&stable_channel_by_version=true",
     )
 
     Request.new(uri, { "access_token" => options.access_token }).do_request(:get).response

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -7,6 +7,7 @@ class Plugin < PluginBase
 
   def initialize(options)
     super(options)
+    @access_token = options.access_token
     @existing_plugin = zapp_plugin unless @create_new_plugin
     @id = @existing_plugin["id"] unless @existing_plugin.nil?
   end

--- a/lib/plugin_base.rb
+++ b/lib/plugin_base.rb
@@ -10,8 +10,7 @@ class PluginBase
     @plugin_guide = get_markdown_data(options.plugin_guide) || @manifest["guide"]
     @plugin_about = get_markdown_data(options.plugin_about) || @manifest["about"]
     @identifier = format_identifier(@manifest["identifier"])
-    @base_url = options.override_url || NetworkHelpers::ZAPP_URL
-    @access_token = options.access_token
+    @base_url = options.base_url
   end
 
   def plugins_url

--- a/lib/plugin_version.rb
+++ b/lib/plugin_version.rb
@@ -14,6 +14,8 @@ class PluginVersion < PluginBase
 
   def initialize(options)
     super(options)
+    @access_token = options.access_token
+
     check_manifest_version_validity
 
     @targets = get_request(targets_url, { "access_token" => @access_token }).body

--- a/lib/zappifest.rb
+++ b/lib/zappifest.rb
@@ -25,7 +25,8 @@ require_relative 'version_helper'
 
 program :name, 'Zappifest'
 program :version, VERSION
-program :description, 'Tool to generate Zapp plugin manifest'
+program :description,
+  "Tool to generate Zapp plugin manifest\n.....................................\nDetailed documentation:\nzappifest publish --help\nzappifest init --help"
 
 command :init do |c|
   c.syntax = 'zappifest init [options]'
@@ -80,16 +81,19 @@ command :publish do |c|
   c.option '--plugin-id PLUGIN_ID', String, 'Zapp plugin id, if updating an existing plugin'
   c.option '--manifest PATH', String, 'plugin-manifest.json path'
   c.option '--access-token ACCESS_TOKEN', String, 'Zapp access-token'
-  c.option '--override-url URL', String, 'alternate url'
+  c.option '--base-url URL', String, 'alternate Zapp server url'
+  c.option '--accounts-url URL', String, 'alternate Accounts server url'
   c.option '--new', String, 'use this option to publish a new plugin with a new identifier'
   c.option '--plugin-guide PATH', String, 'markdown file for the plugin guide'
   c.option '--plugin-about PATH', String, 'markdown file for the plugin description'
   c.action do |args, options|
     options.default access_token: ENV["ZAPP_TOKEN"]
+    options.default base_url: NetworkHelpers::ZAPP_URL
+    options.default accounts_url: NetworkHelpers::ACCOUNTS_URL
     options.default manifest: args.first
 
     VersionHelper.new(c).check_version
-    NetworkHelpers.validate_token(options.access_token) unless options.override_url
+    NetworkHelpers.validate_token(options)
 
     color "Gathering plugin information...", :green
 

--- a/lib/zappifest.rb
+++ b/lib/zappifest.rb
@@ -92,6 +92,11 @@ command :publish do |c|
     options.default accounts_url: NetworkHelpers::ACCOUNTS_URL
     options.default manifest: args.first
 
+    unless options.manifest
+      color "Missing required options: --manifest", :red
+      exit
+    end
+
     VersionHelper.new(c).check_version
     NetworkHelpers.validate_token(options)
 


### PR DESCRIPTION
When working _locally_ vs local dev server, the accounts server was never called for.
Improvements:
1. Doing a real check for the validity of the token vs the local accounts server
2. Error message for missing `--manifest` option
3. Getting all default options from the start of the `publish` command
