### PR TITLE
chore: add new key min_quick_brick_sdk to defined min qb version

### DIFF
--- a/lib/manifest_helpers.rb
+++ b/lib/manifest_helpers.rb
@@ -62,6 +62,7 @@ module ManifestHelpers
     localizations
     ui_frameworks
     characteristics
+    min_quick_brick_sdk
   ].freeze
 
   Types = [


### PR DESCRIPTION
Add new key min_quick_brick_sdk to defined min qb version
[Ticket](https://applicaster.monday.com/boards/1615228456/views/35072856/pulses/3604932489?userId=16469543)